### PR TITLE
Clear 2 warnings about hiding inherited members

### DIFF
--- a/KickassUI.ParallaxCarousel/Controls/RoundedButton.cs
+++ b/KickassUI.ParallaxCarousel/Controls/RoundedButton.cs
@@ -5,9 +5,9 @@ namespace KickassUI.ParallaxCarousel.Controls
 { 
     public class RoundedButton : Button
     {
-        public static readonly BindableProperty PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Thickness), typeof(RoundedButton), new Thickness(0, 0, 0, 0));
+        public new static readonly BindableProperty PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Thickness), typeof(RoundedButton), new Thickness(0, 0, 0, 0));
 
-        public Thickness Padding
+        public new Thickness Padding
         {
             get { return (Thickness)GetValue(PaddingProperty); }
             set { SetValue(PaddingProperty, value); }


### PR DESCRIPTION
Fixed these 2 warnings

> KickassUI.ParallaxCarousel/Controls/RoundedButton.cs(49,49): Warning CS0108: 'RoundedButton.PaddingProperty' hides inherited member 'Button.PaddingProperty'. Use the new keyword if hiding was intended. (CS0108) (KickassUI.ParallaxCarousel)
> 
> KickassUI.ParallaxCarousel/Controls/RoundedButton.cs(26,26): Warning CS0108: 'RoundedButton.Padding' hides inherited member 'Button.Padding'. Use the new keyword if hiding was intended. (CS0108) (KickassUI.ParallaxCarousel)