### PR TITLE
Removed 2 obsolete properties

### DIFF
--- a/KickassUI.ParallaxCarousel/Controls/RoundedButton.cs
+++ b/KickassUI.ParallaxCarousel/Controls/RoundedButton.cs
@@ -5,14 +5,7 @@ namespace KickassUI.ParallaxCarousel.Controls
 { 
     public class RoundedButton : Button
     {
-        public static readonly BindableProperty PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Thickness), typeof(RoundedButton), new Thickness(0, 0, 0, 0));
-
-        public Thickness Padding
-        {
-            get { return (Thickness)GetValue(PaddingProperty); }
-            set { SetValue(PaddingProperty, value); }
-        }
-
+        
         private bool _measured = false;
         private bool _self = false;
 


### PR DESCRIPTION
Removed 2 properties to fix these warnings

>    KickassUI.ParallaxCarousel/Controls/RoundedButton.cs(49,49): Warning CS0108: 'RoundedButton.PaddingProperty' hides inherited member 'Button.PaddingProperty'. Use the new keyword if hiding was intended. (CS0108) (KickassUI.ParallaxCarousel)
>
>    KickassUI.ParallaxCarousel/Controls/RoundedButton.cs(26,26): Warning CS0108: 'RoundedButton.Padding' hides inherited member 'Button.Padding'. Use the new keyword if hiding was intended. (CS0108) (KickassUI.ParallaxCarousel)

As discussed [in this PR](https://github.com/sthewissen/KickassUI.ParallaxCarousel/pull/3#issuecomment-499122446)